### PR TITLE
Fix typo on Legal Aid page

### DIFF
--- a/app/views/questions/legalaid.html.erb
+++ b/app/views/questions/legalaid.html.erb
@@ -25,7 +25,7 @@
 
 <div class="well">
 <p style="margin: 0 0 0 0">
-	If you were arrested outside of Cook County: search for your zip code <a href="http://www.illinoislegalaid.org/index.cfm?fuseaction=home.dsp_content&contentID=7064#a=legalhelp">here</a> to find a free legail aid organization in your area.
+	If you were arrested outside of Cook County: search for your zip code <a href="http://www.illinoislegalaid.org/index.cfm?fuseaction=home.dsp_content&contentID=7064#a=legalhelp">here</a> to find a free legal aid organization in your area.
 
 </p>
 </div>


### PR DESCRIPTION
This fixes a minor typo on the Legal Aid page—it said "legail" instead of "legal".