### PR TITLE
Add link to Legal Aid on disclaimer page

### DIFF
--- a/app/views/questions/disclaimer.html.erb
+++ b/app/views/questions/disclaimer.html.erb
@@ -2,8 +2,8 @@
 
 <h2>DISCLAIMER</h2>
 <p>
-    This site <i><b>does not serve as a substitute for legal aid</b></i>. 
-    If you're unsure about any questions, you can speak with a lawyer (for free!) by clicking Legal Help at the top of the page.
+    This site <i><b>does not serve as a substitute for legal aid</b></i>.
+    If you're unsure about any questions, you can speak with a lawyer (for free!) by clicking <a href="/legalaid">Legal Aid</a>.
 </p>
 
 <p>


### PR DESCRIPTION
Here's what the disclaimer page looks like after this pull request:

![Screenshot of the disclaimer page](https://cloud.githubusercontent.com/assets/777712/9524620/a4fd04d2-4c94-11e5-8990-3ac747648cf4.png)